### PR TITLE
Add the getblockcount Command

### DIFF
--- a/lib/VerusdRpcInterface.d.ts
+++ b/lib/VerusdRpcInterface.d.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance, AxiosRequestConfig } from "axios";
-import { GetAddressBalanceRequest, ApiRequest, GetAddressDeltasRequest, GetAddressUtxosRequest, GetBlockRequest, GetIdentityRequest, GetIdentityContentRequest, GetInfoRequest, GetOffersRequest, GetRawTransactionRequest, MakeOfferRequest, SendRawTransactionRequest, GetCurrencyRequest, GetAddressMempoolRequest, GetVdxfIdRequest, FundRawTransactionRequest, SendCurrencyRequest, GetCurrencyConvertersRequest, CurrencyDefinition, ApiResponse, ListCurrenciesRequest, EstimateConversionRequest, ZGetOperationStatusRequest } from "verus-typescript-primitives";
+import { GetAddressBalanceRequest, ApiRequest, GetAddressDeltasRequest, GetAddressUtxosRequest, GetBlockRequest, GetBlockCountRequest, GetIdentityRequest, GetIdentityContentRequest, GetInfoRequest, GetOffersRequest, GetRawTransactionRequest, MakeOfferRequest, SendRawTransactionRequest, GetCurrencyRequest, GetAddressMempoolRequest, GetVdxfIdRequest, FundRawTransactionRequest, SendCurrencyRequest, GetCurrencyConvertersRequest, CurrencyDefinition, ApiResponse, ListCurrenciesRequest, EstimateConversionRequest, ZGetOperationStatusRequest } from "verus-typescript-primitives";
 import { ConstructorParametersAfterFirst } from "./types/ConstructorParametersAfterFirst";
 import { RpcRequestBody, RpcRequestResult } from "./types/RpcRequest";
 declare type Convertable = {
@@ -99,6 +99,7 @@ declare class VerusdRpcInterface {
         blocktime: number;
     }[], any>>;
     getBlock(...args: ConstructorParametersAfterFirst<typeof GetBlockRequest>): Promise<RpcRequestResult<string | import("verus-typescript-primitives/dist/block/BlockInfo").BlockInfo, any>>;
+    getBlockCount(...args: ConstructorParametersAfterFirst<typeof GetBlockCountRequest>): Promise<RpcRequestResult<number, any>>;
     getVdxfId(...args: ConstructorParametersAfterFirst<typeof GetVdxfIdRequest>): Promise<RpcRequestResult<{
         vdxfid: string;
         hash160result: string;

--- a/lib/VerusdRpcInterface.js
+++ b/lib/VerusdRpcInterface.js
@@ -90,6 +90,9 @@ class VerusdRpcInterface {
     getBlock(...args) {
         return this.request(new verus_typescript_primitives_1.GetBlockRequest(this.chain, ...args));
     }
+    getBlockCount(...args) {
+        return this.request(new verus_typescript_primitives_1.GetBlockCountRequest(this.chain, ...args));
+    }
     getVdxfId(...args) {
         return this.request(new verus_typescript_primitives_1.GetVdxfIdRequest(this.chain, ...args));
     }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
   ],
   "dependencies": {
     "axios": "1.7.4",
-    "verus-typescript-primitives": "git+https://github.com/VerusCoin/verus-typescript-primitives.git"
+    "verus-typescript-primitives": "https://github.com/mcstoer/verus-typescript-primitives.git#getblockcount"
   }
 }

--- a/src/VerusdRpcInterface.ts
+++ b/src/VerusdRpcInterface.ts
@@ -5,6 +5,7 @@ import {
   GetAddressDeltasRequest,
   GetAddressUtxosRequest,
   GetBlockRequest,
+  GetBlockCountRequest,
   GetIdentityRequest,
   GetIdentityContentRequest,
   GetInfoRequest,
@@ -17,6 +18,7 @@ import {
   GetAddressDeltasResponse,
   GetAddressUtxosResponse,
   GetBlockResponse,
+  GetBlockCountResponse,
   GetIdentityResponse,
   GetCurrencyResponse,
   GetInfoResponse,
@@ -159,6 +161,10 @@ class VerusdRpcInterface {
 
   getBlock(...args: ConstructorParametersAfterFirst<typeof GetBlockRequest>) {
     return this.request<GetBlockResponse["result"]>(new GetBlockRequest(this.chain, ...args));
+  }
+
+  getBlockCount(...args: ConstructorParametersAfterFirst<typeof GetBlockCountRequest>) {
+    return this.request<GetBlockCountResponse["result"]>(new GetBlockCountRequest(this.chain, ...args));
   }
 
   getVdxfId(...args: ConstructorParametersAfterFirst<typeof GetVdxfIdRequest>) {

--- a/src/__tests__/live/rpc.test.ts
+++ b/src/__tests__/live/rpc.test.ts
@@ -62,6 +62,12 @@ describe('Makes live API Verusd RPC calls', () => {
     expect(!!(await verusd.getBlock("1")).error).toBe(false);
   });
 
+  test("getblockcount", async () => {
+    const res = await verusd.getBlockCount();
+    expect(!!res.error).toBe(false);
+    expect(res.result).toBeGreaterThanOrEqual(0);
+  });
+
   test('getidentity', async () => {
     expect(
       !!(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2890,9 +2890,9 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
 
-"verus-typescript-primitives@git+https://github.com/VerusCoin/verus-typescript-primitives.git":
+"verus-typescript-primitives@https://github.com/mcstoer/verus-typescript-primitives.git#getblockcount":
   version "1.0.0"
-  resolved "git+https://github.com/VerusCoin/verus-typescript-primitives.git#ca149bcef98d226ffc6eccfd4bd089620ca2c965"
+  resolved "https://github.com/mcstoer/verus-typescript-primitives.git#3417cc99004b98103b5187e82c516a81498accc4"
   dependencies:
     base64url "3.0.1"
     bech32 "2.0.0"


### PR DESCRIPTION
Adds the `getblockcount` command to the API.

See https://github.com/VerusCoin/verus-typescript-primitives/pull/32 for the implementation in `verus-typescript-primitives`. 