### PR TITLE
Add API key Authentication

### DIFF
--- a/lib/VerusdRpcInterface.d.ts
+++ b/lib/VerusdRpcInterface.d.ts
@@ -14,16 +14,21 @@ type Convertable = {
 type Convertables = {
     [key: string]: Array<Convertable>;
 };
+type APIAuthData = {
+    key: string;
+    id: string;
+};
 declare class VerusdRpcInterface {
     instance?: AxiosInstance;
     currid: number;
     chain: string;
+    APIAuth?: APIAuthData;
     rpcRequestOverride?: <D>(req: RpcRequestBody<number>) => Promise<RpcRequestResult<D>>;
     private currencycache;
     private converterscache;
     private listcurrenciescache;
     private infocache;
-    constructor(chain: string, baseURL: string, config?: AxiosRequestConfig, rpcRequest?: <D>(req: RpcRequestBody<number>) => Promise<RpcRequestResult<D>>);
+    constructor(chain: string, baseURL: string, config?: AxiosRequestConfig, rpcRequest?: <D>(req: RpcRequestBody<number>) => Promise<RpcRequestResult<D>>, APIAuth?: APIAuthData);
     request<D>(req: ApiRequest): Promise<RpcRequestResult<D>>;
     getAddressBalance(...args: ConstructorParametersAfterFirst<typeof GetAddressBalanceRequest>): Promise<RpcRequestResult<{
         balance: number;

--- a/lib/VerusdRpcInterface.d.ts
+++ b/lib/VerusdRpcInterface.d.ts
@@ -23,6 +23,7 @@ declare class VerusdRpcInterface {
     currid: number;
     chain: string;
     APIAuth?: APIAuthData;
+    static VRPC_API_VERSION_CURRENT: string;
     rpcRequestOverride?: <D>(req: RpcRequestBody<number>) => Promise<RpcRequestResult<D>>;
     private currencycache;
     private converterscache;

--- a/lib/VerusdRpcInterface.d.ts
+++ b/lib/VerusdRpcInterface.d.ts
@@ -31,6 +31,7 @@ declare class VerusdRpcInterface {
     private infocache;
     constructor(chain: string, baseURL: string, config?: AxiosRequestConfig, rpcRequest?: <D>(req: RpcRequestBody<number>) => Promise<RpcRequestResult<D>>, APIAuth?: APIAuthData);
     request<D>(req: ApiRequest): Promise<RpcRequestResult<D>>;
+    private getAuthToken;
     getAddressBalance(...args: ConstructorParametersAfterFirst<typeof GetAddressBalanceRequest>): Promise<RpcRequestResult<{
         balance: number;
         received: number;

--- a/lib/VerusdRpcInterface.js
+++ b/lib/VerusdRpcInterface.js
@@ -52,19 +52,25 @@ class VerusdRpcInterface {
                     const time = new Date().valueOf();
                     hash.update(Buffer.from(time.toString(), 'utf-8'));
                     hash.update(Buffer.from(this.APIAuth.key, 'utf-8'));
-                    hash.update(Buffer.from(req.cmd, 'utf-8'));
+                    hash.update(Buffer.from(JSON.stringify(body), 'utf-8'));
                     hash.update(Buffer.from(this.APIAuth.id, 'utf-8'));
+                    hash.update(Buffer.from(VerusdRpcInterface.VRPC_API_VERSION_CURRENT, 'utf-8'));
                     const validityKey = hash.digest("hex");
                     res = yield this.instance.post("/", body, {
                         headers: {
                             ['X-App-ID']: this.APIAuth.id,
                             ['X-Timestamp']: time,
-                            ['X-Auth-Token']: validityKey
+                            ['X-Auth-Token']: validityKey,
+                            ["X-VRPC-API-Version"]: VerusdRpcInterface.VRPC_API_VERSION_CURRENT
                         }
                     });
                 }
                 else {
-                    res = yield this.instance.post("/", body);
+                    res = yield this.instance.post("/", body, {
+                        headers: {
+                            ["X-VRPC-API-Version"]: VerusdRpcInterface.VRPC_API_VERSION_CURRENT
+                        }
+                    });
                 }
                 if (res.status != 200) {
                     const error = {
@@ -588,4 +594,5 @@ class VerusdRpcInterface {
         });
     }
 }
+VerusdRpcInterface.VRPC_API_VERSION_CURRENT = "2";
 exports.default = VerusdRpcInterface;

--- a/lib/VerusdRpcInterface.js
+++ b/lib/VerusdRpcInterface.js
@@ -16,6 +16,7 @@ const blake2b = require('blake2b');
 const axios_1 = __importDefault(require("axios"));
 const verus_typescript_primitives_1 = require("verus-typescript-primitives");
 const flags_1 = require("./utils/flags");
+const crypto_1 = __importDefault(require("crypto"));
 class VerusdRpcInterface {
     constructor(chain, baseURL, config, rpcRequest, APIAuth) {
         this.currencycache = new Map();
@@ -48,20 +49,16 @@ class VerusdRpcInterface {
             try {
                 let res;
                 if (this.APIAuth) {
-                    const hash = blake2b(64);
                     const time = new Date().valueOf();
-                    hash.update(Buffer.from(time.toString(), 'utf-8'));
-                    hash.update(Buffer.from(this.APIAuth.key, 'utf-8'));
-                    hash.update(Buffer.from(JSON.stringify(body), 'utf-8'));
-                    hash.update(Buffer.from(this.APIAuth.id, 'utf-8'));
-                    hash.update(Buffer.from(VerusdRpcInterface.VRPC_API_VERSION_CURRENT, 'utf-8'));
-                    const validityKey = hash.digest("hex");
+                    const salt = crypto_1.default.randomBytes(32);
+                    const validityKey = this.getAuthToken(time, body, salt);
                     res = yield this.instance.post("/", body, {
                         headers: {
                             ['X-App-ID']: this.APIAuth.id,
                             ['X-Timestamp']: time,
                             ['X-Auth-Token']: validityKey,
-                            ["X-VRPC-API-Version"]: VerusdRpcInterface.VRPC_API_VERSION_CURRENT
+                            ["X-VRPC-API-Version"]: VerusdRpcInterface.VRPC_API_VERSION_CURRENT,
+                            ['X-Salt']: salt.toString('hex')
                         }
                     });
                 }
@@ -101,6 +98,16 @@ class VerusdRpcInterface {
                 return error;
             }
         });
+    }
+    getAuthToken(time, body, salt) {
+        const hash = blake2b(64);
+        hash.update(Buffer.from(time.toString(), 'utf-8'));
+        hash.update(Buffer.from(this.APIAuth.key, 'utf-8'));
+        hash.update(Buffer.from(JSON.stringify(body), 'utf-8'));
+        hash.update(Buffer.from(this.APIAuth.id, 'utf-8'));
+        hash.update(Buffer.from(VerusdRpcInterface.VRPC_API_VERSION_CURRENT, 'utf-8'));
+        hash.update(salt);
+        return hash.digest("hex");
     }
     getAddressBalance(...args) {
         return this.request(new verus_typescript_primitives_1.GetAddressBalanceRequest(this.chain, ...args));

--- a/lib/VerusdRpcInterface.js
+++ b/lib/VerusdRpcInterface.js
@@ -12,11 +12,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const blake2b = require('blake2b');
 const axios_1 = __importDefault(require("axios"));
 const verus_typescript_primitives_1 = require("verus-typescript-primitives");
 const flags_1 = require("./utils/flags");
 class VerusdRpcInterface {
-    constructor(chain, baseURL, config, rpcRequest) {
+    constructor(chain, baseURL, config, rpcRequest, APIAuth) {
         this.currencycache = new Map();
         this.converterscache = new Map();
         this.listcurrenciescache = new Map();
@@ -30,6 +31,7 @@ class VerusdRpcInterface {
         }
         this.currid = 0;
         this.chain = chain;
+        this.APIAuth = APIAuth;
     }
     request(req) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -44,7 +46,26 @@ class VerusdRpcInterface {
             if (this.rpcRequestOverride)
                 return this.rpcRequestOverride(body);
             try {
-                const res = yield this.instance.post("/", body);
+                let res;
+                if (this.APIAuth) {
+                    const hash = blake2b(64);
+                    const time = new Date().valueOf();
+                    hash.update(Buffer.from(time.toString(), 'utf-8'));
+                    hash.update(Buffer.from(this.APIAuth.key, 'utf-8'));
+                    hash.update(Buffer.from(req.cmd, 'utf-8'));
+                    hash.update(Buffer.from(this.APIAuth.id, 'utf-8'));
+                    const validityKey = hash.digest("hex");
+                    res = yield this.instance.post("/", body, {
+                        headers: {
+                            ['X-App-ID']: this.APIAuth.id,
+                            ['X-Timestamp']: time,
+                            ['X-Auth-Token']: validityKey
+                        }
+                    });
+                }
+                else {
+                    res = yield this.instance.post("/", body);
+                }
                 if (res.status != 200) {
                     const error = {
                         id,

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   ],
   "dependencies": {
     "axios": "1.11.0",
-    "verus-typescript-primitives": "git+https://github.com/VerusCoin/verus-typescript-primitives.git"
+    "verus-typescript-primitives": "git+https://github.com/VerusCoin/verus-typescript-primitives.git",
+    "blake2b": "https://github.com/VerusCoin/blake2b"
   },
   "resolutions": {
     "brace-expansion": "1.1.12",

--- a/src/VerusdRpcInterface.ts
+++ b/src/VerusdRpcInterface.ts
@@ -55,6 +55,7 @@ import {
 import { ConstructorParametersAfterFirst, RemoveFirstFromTuple } from "./types/ConstructorParametersAfterFirst";
 import { RpcRequestBody, RpcRequestResult, RpcRequestResultError, RpcRequestResultSuccess } from "./types/RpcRequest";
 import { IS_FRACTIONAL_FLAG, IS_GATEWAY_CONVERTER_FLAG, IS_GATEWAY_FLAG, checkFlag } from "./utils/flags";
+import crypto from "crypto";
 
 type Convertable = {
   via?: CurrencyDefinition,
@@ -125,23 +126,18 @@ class VerusdRpcInterface {
       let res: AxiosResponse;
 
       if (this.APIAuth) {
-        const hash = blake2b(64);
         const time = new Date().valueOf();
+        const salt = crypto.randomBytes(32);
 
-        hash.update(Buffer.from(time.toString(), 'utf-8'));
-        hash.update(Buffer.from(this.APIAuth!.key, 'utf-8'));
-        hash.update(Buffer.from(JSON.stringify(body), 'utf-8'));
-        hash.update(Buffer.from(this.APIAuth!.id, 'utf-8'));
-        hash.update(Buffer.from(VerusdRpcInterface.VRPC_API_VERSION_CURRENT, 'utf-8'));
-
-        const validityKey = hash.digest("hex");
+        const validityKey = this.getAuthToken(time, body, salt);
 
         res = await this.instance!.post("/", body, {
           headers: {
             ['X-App-ID']: this.APIAuth!.id,
             ['X-Timestamp']: time,
             ['X-Auth-Token']: validityKey,
-            ["X-VRPC-API-Version"]: VerusdRpcInterface.VRPC_API_VERSION_CURRENT
+            ["X-VRPC-API-Version"]: VerusdRpcInterface.VRPC_API_VERSION_CURRENT,
+            ['X-Salt']: salt.toString('hex')
           }
         });
       } else {
@@ -181,6 +177,19 @@ class VerusdRpcInterface {
 
       return error;
     }
+  }
+
+  private getAuthToken(time: number, body: RpcRequestBody<number>, salt: Buffer): string {
+    const hash = blake2b(64);
+
+    hash.update(Buffer.from(time.toString(), 'utf-8'));
+    hash.update(Buffer.from(this.APIAuth!.key, 'utf-8'));
+    hash.update(Buffer.from(JSON.stringify(body), 'utf-8'));
+    hash.update(Buffer.from(this.APIAuth!.id, 'utf-8'));
+    hash.update(Buffer.from(VerusdRpcInterface.VRPC_API_VERSION_CURRENT, 'utf-8'));
+    hash.update(salt);
+
+    return hash.digest("hex");
   }
 
   getAddressBalance(...args: ConstructorParametersAfterFirst<typeof GetAddressBalanceRequest>) {

--- a/src/VerusdRpcInterface.ts
+++ b/src/VerusdRpcInterface.ts
@@ -76,6 +76,8 @@ class VerusdRpcInterface {
   chain: string;
   APIAuth?: APIAuthData;
 
+  static VRPC_API_VERSION_CURRENT = "2";
+
   rpcRequestOverride?: <D>(req: RpcRequestBody<number>) => Promise<RpcRequestResult<D>>;
 
   private currencycache: Map<string, RpcRequestResultSuccess<GetCurrencyResponse["result"]>> = new Map();
@@ -128,8 +130,9 @@ class VerusdRpcInterface {
 
         hash.update(Buffer.from(time.toString(), 'utf-8'));
         hash.update(Buffer.from(this.APIAuth!.key, 'utf-8'));
-        hash.update(Buffer.from(req.cmd, 'utf-8'));
+        hash.update(Buffer.from(JSON.stringify(body), 'utf-8'));
         hash.update(Buffer.from(this.APIAuth!.id, 'utf-8'));
+        hash.update(Buffer.from(VerusdRpcInterface.VRPC_API_VERSION_CURRENT, 'utf-8'));
 
         const validityKey = hash.digest("hex");
 
@@ -137,11 +140,16 @@ class VerusdRpcInterface {
           headers: {
             ['X-App-ID']: this.APIAuth!.id,
             ['X-Timestamp']: time,
-            ['X-Auth-Token']: validityKey
+            ['X-Auth-Token']: validityKey,
+            ["X-VRPC-API-Version"]: VerusdRpcInterface.VRPC_API_VERSION_CURRENT
           }
         });
       } else {
-        res = await this.instance!.post("/", body);
+        res = await this.instance!.post("/", body, {
+          headers: {
+            ["X-VRPC-API-Version"]: VerusdRpcInterface.VRPC_API_VERSION_CURRENT
+          }
+        });
       }
 
       if (res.status != 200) {

--- a/src/VerusdRpcInterface.ts
+++ b/src/VerusdRpcInterface.ts
@@ -1,3 +1,5 @@
+const blake2b = require('blake2b');
+
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import {
   GetAddressBalanceRequest,
@@ -66,10 +68,13 @@ type Convertable = {
 
 type Convertables = { [key: string]: Array<Convertable> }
 
+type APIAuthData = { key: string, id: string }
+
 class VerusdRpcInterface {
   instance?: AxiosInstance;
   currid: number;
   chain: string;
+  APIAuth?: APIAuthData;
 
   rpcRequestOverride?: <D>(req: RpcRequestBody<number>) => Promise<RpcRequestResult<D>>;
 
@@ -78,7 +83,13 @@ class VerusdRpcInterface {
   private listcurrenciescache: Map<string, RpcRequestResultSuccess<ListCurrenciesResponse["result"]>> = new Map();
   private infocache: RpcRequestResultSuccess<GetInfoResponse["result"]> | null = null;
 
-  constructor(chain: string, baseURL: string, config?: AxiosRequestConfig, rpcRequest?: <D>(req: RpcRequestBody<number>) => Promise<RpcRequestResult<D>>) {
+  constructor(
+    chain: string, 
+    baseURL: string, 
+    config?: AxiosRequestConfig, 
+    rpcRequest?: <D>(req: RpcRequestBody<number>) => Promise<RpcRequestResult<D>>, 
+    APIAuth?: APIAuthData
+  ) {
     if (rpcRequest) this.rpcRequestOverride = rpcRequest;
     else {
       this.instance = axios.create({
@@ -92,6 +103,7 @@ class VerusdRpcInterface {
 
     this.currid = 0;
     this.chain = chain;
+    this.APIAuth = APIAuth;
   }
 
   async request<D>(req: ApiRequest): Promise<RpcRequestResult<D>> {
@@ -108,7 +120,29 @@ class VerusdRpcInterface {
     if (this.rpcRequestOverride) return this.rpcRequestOverride(body);
  
     try {
-      const res: AxiosResponse = await this.instance!.post("/", body);
+      let res: AxiosResponse;
+
+      if (this.APIAuth) {
+        const hash = blake2b(64);
+        const time = new Date().valueOf();
+
+        hash.update(Buffer.from(time.toString(), 'utf-8'));
+        hash.update(Buffer.from(this.APIAuth!.key, 'utf-8'));
+        hash.update(Buffer.from(req.cmd, 'utf-8'));
+        hash.update(Buffer.from(this.APIAuth!.id, 'utf-8'));
+
+        const validityKey = hash.digest("hex");
+
+        res = await this.instance!.post("/", body, {
+          headers: {
+            ['X-App-ID']: this.APIAuth!.id,
+            ['X-Timestamp']: time,
+            ['X-Auth-Token']: validityKey
+          }
+        });
+      } else {
+        res = await this.instance!.post("/", body);
+      }
 
       if (res.status != 200) {
         const error: RpcRequestResultError = {


### PR DESCRIPTION
- Adds optional API key authentication for RPC requests using BLAKE2b token generation

- Each request generates a unique auth token derived from: timestamp, API key, request body (JSON), app ID, API version, and a random 32-byte salt

- Adds X-VRPC-API-Version, X-App-ID, X-Timestamp, X-Auth-Token, and X-Salt headers to authenticated requests; X-VRPC-API-Version is sent on all requests

- Constructor accepts an optional APIAuth parameter ({ key: string, id: string }) to enable authenticated mode
Introduces VerusdRpcInterface.VRPC_API_VERSION_CURRENT static constant (currently "2")